### PR TITLE
Fixed casing typo on ClusterRole

### DIFF
--- a/cronjob-scaler/templates/service-account-rbac.yaml
+++ b/cronjob-scaler/templates/service-account-rbac.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["Pods"]
   verbs: ["get", "list"]
 - apiGroups: ["apps", "extensions"]
-  resources: ["DeploymentConfigs", "Deployments", "StatefulSets"]
+  resources: ["deploymentconfigs", "deployments", "statefulsets"]
   verbs: ["get", "list", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cronjob-scaler/templates/service-account-rbac.yaml
+++ b/cronjob-scaler/templates/service-account-rbac.yaml
@@ -13,7 +13,7 @@ metadata:
   name: cronjob-scaler
 rules:
 - apiGroups: ["*"]
-  resources: ["Pods"]
+  resources: ["pods"]
   verbs: ["get", "list"]
 - apiGroups: ["apps", "extensions"]
   resources: ["deploymentconfigs", "deployments", "statefulsets"]


### PR DESCRIPTION
Issue:

When running the cron configuration, it appears to deploy correctly on `4.12.23` but the cron job fails when the date comes, with error

```bash
╰─ oc logs cronjob-scaler-scale-down-28162639-2lq88
Error from server (Forbidden): deployments.apps "my-deployment" is forbidden: User "system:serviceaccount:mynamespace:cronjob-scaler" cannot get resource "deployments" in API group "apps" in the namespace "mynamespace"
```

and upon closer inspection it appears the `ClusterRole` definition has the resources in Pascal Casing, and `oc describe clusterrole.rbac` and `oc api-resources` show all of them in lowercase.

This PR fixes this, as my deployment scales as expected.